### PR TITLE
PR label이 Github Issue label 값을 그대로 따라가도록 설정한다.

### DIFF
--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -1,0 +1,54 @@
+name: Sync PR Labels
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  sync_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync Labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const issueMatches = pr.data.body.matchAll(/#(\d+)/g);
+            const issueNumbers = Array.from(issueMatches, match => match[1]);
+
+            if (issueNumbers.length === 0) return;
+
+            const allLabels = new Set();
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+                
+                issue.data.labels.forEach(label => {
+                  allLabels.add(label.name);
+                });
+              } catch (error) {
+                console.log(`Error fetching issue #${issueNumber}:`, error);
+              }
+            }
+
+            if (allLabels.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: Array.from(allLabels)
+              });
+            }

--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   sync_labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- IMPORTANT: PR 을 만들기 전에 꼭 Issue 를 먼저 생성해주세요. -->

### Motivation
* 깃헙 이슈의 label 값을 pr에 sync 맞추기 위해 workflow를 추가합니다.
<!-- 이 PR 만들게 된 동기 및 배경에 대해서 작성해주세요 -->
<!-- 현재 존재하는 문제가 무엇인지?-->

| Reference | Links |
| --------- | ----- |
| Issue     |   https://github.com/SWYP-team-2th/client/issues/15    |

---

### Modification
* pr label 값이 github issue label 값과 동기화됩니다.
* 연결된 issue가 여러개이면, 중복된 라벨 값을 제거하고 해당되는 모들 라벨 값을 적용합니다.
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

---

### Result
close #15 
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve #XXXX 를 넣어서 PR 이 머지될경우 닫아야할 이슈번호를 명시해주세요. -->

---
