### PR TITLE
라우터 구조 설정 및 기본 레이아웃 적용

### DIFF
--- a/src/components/common/layout/DefaultLayout.tsx
+++ b/src/components/common/layout/DefaultLayout.tsx
@@ -1,5 +1,9 @@
+import { Outlet } from 'react-router-dom';
+
 export default function DefaultLayout() {
   return (
-    <div className="w-full h-full mx-auto my-0 min-h-lvh border-x-[1px] desktop:w-[480px]"></div>
+    <div className="w-full h-full mx-auto my-0 min-h-lvh border-x-[1px] desktop:w-[480px]">
+      <Outlet />
+    </div>
   );
 }

--- a/src/components/common/layout/SubLayout.tsx
+++ b/src/components/common/layout/SubLayout.tsx
@@ -1,5 +1,9 @@
+import { Outlet } from 'react-router-dom';
+
 export default function SubLayout() {
   return (
-    <div className="w-full h-full mx-auto my-0 min-h-lvh border-x-[1px] desktop:w-[480px]"></div>
+    <div className="w-full h-full mx-auto my-0 min-h-lvh border-x-[1px] desktop:w-[480px]">
+      <Outlet />
+    </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
+import { RouterProvider } from 'react-router-dom';
+import { router } from '@/routes/routing.tsx';
 import './index.css';
 
 const queryClient = new QueryClient({
@@ -26,7 +27,7 @@ prepareMSW().then(() => {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <RouterProvider router={router} />
       </QueryClientProvider>
     </StrictMode>,
   );

--- a/src/pages/onboarding/OnBoardingPage.tsx
+++ b/src/pages/onboarding/OnBoardingPage.tsx
@@ -1,0 +1,3 @@
+export default function OnBoardingPage() {
+  return <div>OnBoardingPage</div>;
+}

--- a/src/pages/post/PostPage.tsx
+++ b/src/pages/post/PostPage.tsx
@@ -1,0 +1,3 @@
+export default function PostPage() {
+  return <div>PostPage</div>;
+}

--- a/src/routes/routing.tsx
+++ b/src/routes/routing.tsx
@@ -1,0 +1,23 @@
+import { createBrowserRouter } from 'react-router-dom';
+import App from '@/App';
+import DefaultLayout from '@/components/common/layout/DefaultLayout';
+import SubLayout from '@/components/common/layout/SubLayout';
+import OnBoardingPage from '@/pages/onboarding/OnBoardingPage';
+import PostPage from '@/pages/post/PostPage';
+
+export const router = createBrowserRouter([
+  {
+    element: <DefaultLayout />,
+    children: [
+      { path: '/', element: <App /> },
+      {
+        path: '/posts/:shareUrl',
+        element: <PostPage />,
+      },
+    ],
+  },
+  {
+    element: <SubLayout />,
+    children: [{ path: '/onboarding', element: <OnBoardingPage /> }],
+  },
+]);


### PR DESCRIPTION
<!-- IMPORTANT: PR 을 만들기 전에 꼭 Issue 를 먼저 생성해주세요. -->

### Motivation

<!-- 이 PR 만들게 된 동기 및 배경에 대해서 작성해주세요 -->
<!-- 현재 존재하는 문제가 무엇인지?-->

| Reference | Links |
| --------- | ----- |
| Issue     |  #70     |

---

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

각 레이아웃에 Outlet 사용하여 하위 컴포넌트들이 해당 레이아웃을 따라가도록 설정하였습니다.

현재로썬,
플로팅 버튼이 필요한 페이지 → `DefaultLayout` 적용
버튼 등 추가 설정이 필요 없는 페이지 → `SubLayout` 적용
각 페이지는 해당 레이아웃 내부의 `children` 배열에 path, element 추가하여 세팅해주시면 됩니다.

사진 확대 페이지, 게시글 페이지 둘 다 게시글과 관련되어 이와 같이 폴더, 파일명을 작성하였는데 다른 직관적인 파일 및 폴더 명, 폴더 구조 관련 의견 주시면 반영하겠습니다.

API 참고하여 라우터 경로 싱크 맞춰보려고 얼추 비슷하게 따라갔는데 경로 관련하여 의견 주시면 반영하겠습니다.

일단 `'/'` 경로를 `<App />` 으로 설정해두었는데 추후에 페이지 파시면서 마이페이지로 라우터 설정해주시면 될 것 같아요!

---

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve #XXXX 를 넣어서 PR 이 머지될경우 닫아야할 이슈번호를 명시해주세요. -->
close #70 

---
