### PR TITLE
2장 이상 업로드할 때 맨앞 2개만 선택하더라도 게시글에서는 업로드할 때 선택한 사진 수만큼 나옴

### DIFF
--- a/src/components/vote-regist/VoteImages/ImageUploader/hooks.ts
+++ b/src/components/vote-regist/VoteImages/ImageUploader/hooks.ts
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { MAX_IMAGE_COUNT } from '../../constants';
 import useVoteRegist from '../../Provider/hooks';
 import usePostUploadImage from '@/api/usePostUploadImage';
 
@@ -26,7 +27,7 @@ export default function useImageUploader() {
     if (files.length === 0) return;
 
     const formData = new FormData();
-    files.forEach((file) => {
+    files.slice(0, MAX_IMAGE_COUNT).forEach((file) => {
       formData.append('files', file);
     });
 


### PR DESCRIPTION
<!-- IMPORTANT: PR 을 만들기 전에 꼭 Issue 를 먼저 생성해주세요. -->

### Motivation
* 이미지 프리뷰는 2장 제한이 되어있는데, 3장 이상 등록은 가능하다.
<!-- 이 PR 만들게 된 동기 및 배경에 대해서 작성해주세요 -->
<!-- 현재 존재하는 문제가 무엇인지?-->

| Reference | Links |
| --------- | ----- |
| Issue     |   https://www.notion.so/portfolio-ohyunseong/2-2-1a9c0eb655cb80c6b52ffd2a8f65ff83?pvs=4    |

---

### Modification
* 2개까지 잘라서 업로드하도록 수정
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

---

### Result
resolve https://www.notion.so/portfolio-ohyunseong/2-2-1a9c0eb655cb80c6b52ffd2a8f65ff83?pvs=4
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve #XXXX 를 넣어서 PR 이 머지될경우 닫아야할 이슈번호를 명시해주세요. -->

---
