### PR TITLE
화면 축소 시 온보딩 Pagenation dot과 하단 버튼이 겹치는 상황에 대응한다.

### DIFF
--- a/src/constants/onboarding.ts
+++ b/src/constants/onboarding.ts
@@ -12,8 +12,8 @@ export const onBoardingSlides = [
   {
     id: 2,
     image: onboarding2,
-    title: `고민되는 사진을 올리고,\n투표를 받아보세요!`,
-    subtitle: `사진을 올리면, 친구의 투표 시작!\n더 많은 표를 받을 사진은?`,
+    title: `어떤 사진이 더 인기 있을까?\n사진을 올리면 친구들의 투표 시작!`,
+    subtitle: `투표 받고, 친구들의 반응을\n미리 확인하세요!`,
   },
   {
     id: 3,

--- a/src/pages/OnBoarding/OnBoardingPage.tsx
+++ b/src/pages/OnBoarding/OnBoardingPage.tsx
@@ -7,25 +7,27 @@ import { onBoardingSlides } from '@/constants/onboarding';
 
 export default function OnBoardingPage() {
   return (
-    <div className="flex flex-col justify-between w-full h-screen px-7 relative">
+    <div className="flex flex-col w-full h-screen px-7">
       <div className="flex-1 flex items-center min-h-0">
         <Swiper
           modules={[Pagination]}
           slidesPerView={1}
           pagination={{ clickable: true }}
-          className="w-full"
         >
           {onBoardingSlides.map((slide) => (
             <SwiperSlide key={slide.id}>
               <div className="h-full flex flex-col items-center text-center">
-                <span className="text-h1 whitespace-pre-line mt-[120px] mb-[12px]">
+                <span className="text-h3 whitespace-pre-line mt-[5vh] mb-[12px]">
                   {slide.title}
                 </span>
 
                 <span className="text-title-small whitespace-pre-line mb-[18px]">
                   {slide.subtitle}
                 </span>
-                <img src={slide.image} />
+                <img
+                  src={slide.image}
+                  className="max-h-[50vh] object-contain"
+                />
               </div>
             </SwiperSlide>
           ))}


### PR DESCRIPTION
<!-- IMPORTANT: PR 을 만들기 전에 꼭 Issue 를 먼저 생성해주세요. -->

### Motivation

<!-- 이 PR 만들게 된 동기 및 배경에 대해서 작성해주세요 -->
<!-- 현재 존재하는 문제가 무엇인지?-->

| Reference | Links |
| --------- | ----- |
| Issue     |   #206     |

---

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

온보딩 title 텍스트 크기, 내용 수정
이미지와 title 윗 공간 반응형 처리하여 줄어들게끔 하여 대응했습니다.
완전 줄이면 겹치지기도 하는데 윤성님이 요청하신 정도는 넉넉하게 해결돼요.

---

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve #XXXX 를 넣어서 PR 이 머지될경우 닫아야할 이슈번호를 명시해주세요. -->

![image](https://github.com/user-attachments/assets/5dcec4a8-6e27-422c-8100-e6e07170be56)


close #206

---
