### PR TITLE
타 유저의 사진 투표 전 투표 유도 이미지가 안 보이는 상황을 해결한다.

### DIFF
--- a/src/components/vote-detail/Vote/VoteResult/VoteResultList.tsx
+++ b/src/components/vote-detail/Vote/VoteResult/VoteResultList.tsx
@@ -16,8 +16,20 @@ export default function VoteResultList() {
   const { data: myInfo } = useGetMyInfo();
   const [isFullResultShown, setIsFullResultShown] = useState(false);
 
-  // voteStatus 값이 없으면 null로 반환 (undefined 시 대응)
-  if (!voteStatus) return null;
+  if (!voteStatus) {
+    return (
+      <div className="pt-5 pb-4">
+        {!userHasVoted && (
+          <div
+            className="flex items-center justify-center w-full h-18 text-body-2-normal"
+            style={{ backgroundImage: `url(${BlurImage})` }}
+          >
+            <p>투표하고, 뽀또들과 함께 결과를 확인해보세요! 🎉</p>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   const totalVoted = voteStatus.reduce(
     (sum, status) => sum + status.voteCount,


### PR DESCRIPTION
<!-- IMPORTANT: PR 을 만들기 전에 꼭 Issue 를 먼저 생성해주세요. -->

### Motivation

<!-- 이 PR 만들게 된 동기 및 배경에 대해서 작성해주세요 -->
<!-- 현재 존재하는 문제가 무엇인지?-->

| Reference | Links |
| --------- | ----- |
| Issue     | #255       |

---

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

기존에 voteStatus가 아직 로드되지 않은 상태에서 early return하여 투표하지 않은 사용자에게 보여지는 결과 이미지가 뜨지 않았음.
voteStatus가 없을 때에도 투표 여부에 따라 투표 안내 메시지가 렌더링되도록 수정.

---

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve #XXXX 를 넣어서 PR 이 머지될경우 닫아야할 이슈번호를 명시해주세요. -->

close #255 

---
