### PR TITLE
cn 유틸함수에서 text- 스타일이 오버라이딩되는 문제를 해결한다.

### DIFF
--- a/src/utils/cn/cn.ts
+++ b/src/utils/cn/cn.ts
@@ -1,5 +1,32 @@
 import { clsx, ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      'font-size': [
+        'text-title-1',
+        'text-title-2',
+        'text-title-3',
+        'text-heading-1',
+        'text-heading-2',
+        'text-headline-1',
+        'text-headline-2',
+        'text-headline-3',
+        'text-body-1',
+        'text-body-1-long',
+        'text-body-2',
+        'text-body-2-long',
+        'text-caption-1',
+        'text-caption-2',
+        'text-label-1',
+        'text-label-2',
+        'text-label-3',
+        'text-label-4',
+      ],
+    },
+  },
+});
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 export default cn;


### PR DESCRIPTION
<!-- IMPORTANT: PR 을 만들기 전에 꼭 Issue 를 먼저 생성해주세요. -->

### Motivation
* cn 유틸함수에서 text- 스타일이 오버라이딩되는 문제를 해결한다.
<!-- 이 PR 만들게 된 동기 및 배경에 대해서 작성해주세요 -->
<!-- 현재 존재하는 문제가 무엇인지?-->

| Reference | Links |
| --------- | ----- |
| Issue     |  #329      |

---

### Modification
* cn 유틸함수의 문제였다. 정확히는 tailwind-merge의 twMerge 동작방식의 문제이다.
* `labelVariants({ variant, colorVarient, size }),`를 콘솔로 찍어보니 `text-label-2` 속성이 없었음
* 왜냐하면, twMerge는 prefix가 동일한 속성에 대해서는 오버라이딩해서 text-label-2가 씹히고 text-gray-100만 적용시킨다.
  * https://github.com/dcastil/tailwind-merge/issues/297
  * 이미 리포트된 버그이다.

따라서, 아래와 같이 해결
타이포그라피 토큰, 컬러 토큰이 모두 `text-` prefix로 사용 -> 해당 설계는 크게 문제가 없다.
타이포그라피 토큰을 전부 넣어줘서, 오버라이딩하지 않고 extend하도록 설정을 변경해준다.
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

---

### Result
해피해피
close #329 
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve #XXXX 를 넣어서 PR 이 머지될경우 닫아야할 이슈번호를 명시해주세요. -->

---
