### PR TITLE
온보딩 리다이렉트 조건 수정

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -9,7 +9,7 @@ import HomeFeed from '@/components/home/HomeFeed';
 
 export default function Home() {
   const navigate = useNavigate();
-  const { data: myInfo, isSuccess: isMyInfoSuccess } = useGetMyInfo();
+  const { data: myInfo, isLoading: isMyInfoLoading } = useGetMyInfo();
 
   const [showCoachMark, setShowCoachMark] = useState(true);
 
@@ -19,10 +19,10 @@ export default function Home() {
 
   useEffect(() => {
     // 로그인 하지 않은 사용자는 온보딩으로 리다이렉트
-    if (!myInfo?.id && isMyInfoSuccess) {
+    if (!myInfo?.id && !isMyInfoLoading) {
       navigate('/onboarding', { replace: true });
     }
-  }, [myInfo, navigate, isMyInfoSuccess]);
+  }, [myInfo, myInfo, isMyInfoLoading]);
 
   return (
     <div className="min-h-screen bg-gray-100">


### PR DESCRIPTION
<!-- IMPORTANT: PR 을 만들기 전에 꼭 Issue 를 먼저 생성해주세요. -->

### Motivation

<!-- 이 PR 만들게 된 동기 및 배경에 대해서 작성해주세요 -->
<!-- 현재 존재하는 문제가 무엇인지?-->

| Reference | Links |
| --------- | ----- |
| Issue     |   #412     |

---

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

기존에 홈에서 새로 고침 시 스플래쉬 화면이 깜빡이는 현상 때문에 성공시에만 온보딩으로 리다이렉트하도록 했는데, 토큰이 없는 사용자는 API 요청 자체를 하지 않아서 isMyInfoSuccess가 false가 되어 온보딩으로 가지 않는 문제가 발생하더라구요.

!isMyInfoLoading으로 변경하여 로딩이 완료된 상태에서 사용자 정보가 없으면 온보딩으로 리다이렉트하도록 수정하였습니다.

---

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve #XXXX 를 넣어서 PR 이 머지될경우 닫아야할 이슈번호를 명시해주세요. -->

close #412 

---
