### PR TITLE
Feat/ga4 for prd

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     ></script>
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=G-H3ZTJT4LNW"
+      src="https://www.googletagmanager.com/gtag/js?id=G-E7XGKV9GNF"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -37,7 +37,7 @@
         dataLayer.push(arguments);
       }
       gtag('js', new Date());
-      gtag('config', 'G-H3ZTJT4LNW', {
+      gtag('config', 'G-E7XGKV9GNF', {
         debug_mode: true,
       });
     </script>

--- a/src/components/common/Layout/DefaultLayout.tsx
+++ b/src/components/common/Layout/DefaultLayout.tsx
@@ -1,7 +1,10 @@
 import { Outlet } from 'react-router-dom';
 import Navigation from '@/components/common/Navigation/Navigation';
+import usePageViewTracking from '@/hooks/usePageViewTracking';
 
 export default function DefaultLayout() {
+  usePageViewTracking();
+
   return (
     <div className="relative w-full h-full mx-auto my-0 min-h-lvh max-w-[480px]">
       <div className="pb-[80px]">

--- a/src/components/common/Layout/SubLayout.tsx
+++ b/src/components/common/Layout/SubLayout.tsx
@@ -1,6 +1,9 @@
 import { Outlet } from 'react-router-dom';
+import usePageViewTracking from '@/hooks/usePageViewTracking';
 
 export default function SubLayout() {
+  usePageViewTracking();
+
   return (
     <div className="w-full h-lvh min-h-lvh mx-auto my-0 desktop:w-[480px]">
       <Outlet />

--- a/src/components/poll-detail/Button/PollButton.tsx
+++ b/src/components/poll-detail/Button/PollButton.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
+import ReactGA from 'react-ga4';
 import usePost from '@/api/usePost';
 import { Button } from '@/components/common/Button/Button';
 import useToast from '@/components/common/Toast/hooks';
@@ -16,6 +17,10 @@ export default function PollButton({ postId, checkedItems }: PollButtonProps) {
 
   const { mutate: vote, isPending } = usePost({
     onSuccess: () => {
+      ReactGA.event('poll_voted', {
+        post_id: postId,
+      });
+
       queryClient.invalidateQueries({ queryKey: ['post', String(postId)] });
       queryClient.invalidateQueries({
         queryKey: ['postResult', String(postId)],
@@ -26,7 +31,6 @@ export default function PollButton({ postId, checkedItems }: PollButtonProps) {
         description: '투표가 성공적으로 완료되었어요.',
       });
 
-      // voteMode 종료
       setVoteMode(false);
     },
   });

--- a/src/hooks/usePageViewTracking.ts
+++ b/src/hooks/usePageViewTracking.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import ReactGA from 'react-ga4';
+import { useLocation } from 'react-router-dom';
+
+export default function usePageViewTracking() {
+  const location = useLocation();
+
+  useEffect(() => {
+    ReactGA.send({
+      hitType: 'pageview',
+      page: location.pathname + location.search,
+    });
+  }, [location]);
+}

--- a/src/pages/OnBoarding/OnBoardingPage.tsx
+++ b/src/pages/OnBoarding/OnBoardingPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import ReactGA from 'react-ga4';
 import { useNavigate } from 'react-router-dom';
 import useGetMyInfo from '@/api/useGetMyInfo';
 import onboardingImage from '@/assets/images/onboarding/onboarding.png';
@@ -21,6 +22,12 @@ export default function OnBoardingPage() {
       setShowSplash(false);
     }, 2500);
   }, []);
+
+  useEffect(() => {
+    if (!showSplash) {
+      ReactGA.event('onboarding_viewed');
+    }
+  }, [showSplash]);
 
   if (showSplash) {
     return (

--- a/src/pages/PollDetail/PollResultPage.tsx
+++ b/src/pages/PollDetail/PollResultPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import ReactGA from 'react-ga4';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useGetNotificationPresent } from '@/api/useGetNotificationPresent';
 import { useGetPost } from '@/api/useGetPost';
@@ -28,6 +30,14 @@ export default function PollResultPage() {
       enabled: !!postId,
     },
   });
+
+  useEffect(() => {
+    if (post && result) {
+      ReactGA.event('poll_result_viewed', {
+        post_id: postId,
+      });
+    }
+  }, [post, result, postId]);
 
   if (isPostLoading || isResultLoading) return <Loading />;
   if (!post || !result) return <NotFoundPage />;


### PR DESCRIPTION
### Motivation

GA4 이벤트 트래킹이 부분적으로만 구현되어 있어, 사용자 행동 분석에 필요한 핵심 지표를 수집하지 못하고 있었습니다. 또한 SPA 환경에서 페이지 전환 시 페이지뷰가 자동으로 트래킹되지 않는 문제가 있었습니다.
---

### Modification

**1. SPA 페이지뷰 트래킹 추가**
- `usePageViewTracking` 커스텀 훅 생성
- `DefaultLayout`, `SubLayout`에 훅 적용
- 모든 라우트 전환 시 자동으로 페이지뷰 이벤트 전송

**2. GA4 커스텀 이벤트 추가**
- `poll_result_viewed`: 마감 게시물 결과 페이지 조회 시
- `onboarding_viewed`: 온보딩 화면 진입 시
- `poll_voted`: 투표 참여 시 (재투표/취소 무관)

**3. GA4 측정 ID 변경**
- 운영 환경용 스트림 ID로 변경 (`G-E7XGKV9GNF`)

---

### Result

- GA4에서 SPA 페이지뷰 트래킹 가능
- 마감 게시물 결과 확인 비율 분석 가능
- 온보딩 화면 진입 횟수 측정 가능
- 투표 참여율 분석 가능
- GA4 DebugView에서 실시간 이벤트 확인 가능